### PR TITLE
Enforce local quality gates, migrate ESLint flat config, harden tests, and prep v0.4.1

### DIFF
--- a/.aiconfig
+++ b/.aiconfig
@@ -36,6 +36,11 @@ ai:
         - run: npm install --no-audit --no-fund
         - run: git add package-lock.json
       required: true
+    - name: no-commit-without-lint
+      description: 'Block committing if lint has not been executed in this session.'
+      steps:
+        - assert: last-ran('npm run -s lint')
+      required: true
     - name: no-commit-without-tests
       description: 'Block committing if tests have not been executed in this session.'
       steps:

--- a/.aiconfig
+++ b/.aiconfig
@@ -12,7 +12,7 @@ project:
   knowledge_base: KNOWLEDGE_BASE.md
   project_structure: docs/PROJECT_STRUCTURE.md
   workflows: docs/WORKFLOWS.md
-  license: MIT
+  license: SEE LICENSE IN license.txt
 
 ai:
   preferred_model: claude-3-5-sonnet-20241022
@@ -27,7 +27,19 @@ ai:
       description: 'All changes must pass lint and tests before committing.'
       steps:
         - run: npm run -s lint
-        - run: npm test
+        - run: npm test -s -- --reporter=list
+      required: true
+    - name: package-json-change-requires-install
+      description: 'If package.json is modified, run npm install to update package-lock.json before committing.'
+      when: changes-include('package.json')
+      steps:
+        - run: npm install --no-audit --no-fund
+        - run: git add package-lock.json
+      required: true
+    - name: no-commit-without-tests
+      description: 'Block committing if tests have not been executed in this session.'
+      steps:
+        - assert: last-ran('npm test -s -- --reporter=list')
       required: true
   prompt_templates:
     - 'Summarize this code.'

--- a/.aiconfig
+++ b/.aiconfig
@@ -42,7 +42,7 @@ ai:
         - assert: last-ran('npm run -s lint')
       required: true
     - name: no-commit-without-tests
-      description: 'Block committing if tests have not been executed in this session.'
+      description: 'Block committing if tests have not been executed in this session (list reporter).'
       steps:
         - assert: last-ran('npm test -s -- --reporter=list')
       required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+- What changed and why?
+- Link to issue(s) if any
+
+## Checklist
+
+- [ ] Lint passes locally (npm run -s lint)
+- [ ] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
+- [ ] If package.json changed, I ran `npm install` and committed package-lock.json
+- [ ] Docs updated if behavior changed (README/docs/CHANGELOG)
+
+## Notes for reviewers
+
+- Risks, roll-out plan, or anything unusual reviewers should know

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Running pre-commit checks (lint only)..."
+npm run -s lint-staged || {
+	echo "Lint-staged failed. Aborting commit." >&2
+	exit 1
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 echo "Running pre-commit checks (lint only)..."
 npm run -s lint-staged || {
 	echo "Lint-staged failed. Aborting commit." >&2

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ npx playwright test --grep "your test name" --debug
 
 # Open the latest HTML report
 npx playwright show-report test/report
+
+# Local quality gates (list reporter)
+npm test -s -- --reporter=list
 ```
 
 See [Testing Guide](./docs/TESTING.md) for detailed usage.

--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@ This file lists suggested improvements and additions and their progress for the 
 ## Build & Tooling
 
 - [ ] Optional: Switch package to ESM (add `"type": "module"`) to align with ESLint flat config
-- [x] Version bump to 0.4.0 for robustness/a11y/responsiveness updates
+- [x] Version bump to 0.4.1 (test wait normalization, lint gate in .aiconfig)
 
 ## Reference & Inspiration ✅
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 _No changes yet._
 
+## [0.4.1] - 2025-09-02
+
+### Added
+
+- .aiconfig: Assert last-ran lint policy to mirror the tests gate
+
+### Changed
+
+- Tests: Normalized literal waits (200/300/500/800ms) to shared WAIT buckets; exported WAIT from `test/helpers/test-utils.js`
+- Minor timing harmonization in selection/robustness flows for stability
+
+### Fixed
+
+- Reduced intermittent flake via standardized waits and clearer selection-mode checks
+
+### Misc
+
+- Documentation touch-ups to reflect local quality gates and timing buckets
+
 ## [0.4.0] - 2025-08-28
 
 ### Added

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -53,7 +53,7 @@ Tests are organized by extension states with intelligent configuration:
 - **Error State** - Error condition testing ✅
 - **Common Functionality** - Universal features across all states ✅
 
-### Helper Utilities and Patterns (v0.4.0)
+### Helper Utilities and Patterns (v0.4.0+)
 
 - Stable selectors and signals
   - Root: `.njs-viz[data-render-count]`
@@ -80,17 +80,22 @@ Each test performs targeted cleanup and a properties reset to avoid state leakag
 1. Remove only items added during configuration (`cleanupExtensionConfiguration`).
 2. Clear all selections via toolbar/button.
 3. Open the properties dialog (gear, title="Modify object properties"), replace JSON with `{}`, and Confirm.
-4. Small waits after text clear and Confirm improve stability in headed runs.
+4. Waits use shared WAIT buckets (TINY/SHORT/MED/LONG/XLONG) for clarity and consistency.
 
 ## 🚀 Running Tests
 
-### Prerequisites
+```
+npm test
 
-You need these tools installed:
+npx playwright test --headed
 
-1. **Node.js** (version 20+) - [Download here](https://nodejs.org/)
-2. **Qlik Sense access** - Cloud or Enterprise environment
-3. **Test application** - Created using our provided load script
+npx playwright test --grep "your test name" --debug
+
+npx playwright show-report test/report
+
+# Local quality gate reporter
+npm test -s -- --reporter=list
+```
 
 ### Step 1: Setup Your Environment
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -210,8 +210,7 @@ npx playwright test --headed --grep "Data State"
 # Step-by-step debugging - pause execution
 npx playwright test --debug
 
-# Slow motion - see interactions clearly
-npx playwright test --headed --slowMo=1000
+# Note: slowMo is not supported in this workflow. Prefer --debug or --headed with fewer workers.
 ```
 
 Tip: For flake triage, prefer a single worker:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,17 +35,29 @@ export default [
       'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       'prefer-const': 'error',
       'no-var': 'error',
-      'eqeqeq': 'error',
-      'curly': 'error',
+      eqeqeq: 'error',
+      curly: 'error',
+    },
+  },
+  // Allow CommonJS in test files (Playwright test modules use require/module.exports here)
+  {
+    files: ['test/**/*.js'],
+    languageOptions: {
+      sourceType: 'commonjs',
+    },
+    rules: {
+      // Allow console logs in tests for debugging and traceability
+      'no-console': 'off',
+    },
+  },
+  // But allow ESM for specific test files that use import/export
+  {
+    files: ['test/qs-ext.fixture.js'],
+    languageOptions: {
+      sourceType: 'module',
     },
   },
   {
-    ignores: [
-      'node_modules/**',
-      'dist/**',
-      'bundle-analysis.html',
-      'test/report/**',
-      '*.config.js',
-    ],
+    ignores: ['node_modules/**', 'dist/**', 'bundle-analysis.html', 'test/report/**', '*.config.js'],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,12 @@
         "@playwright/test": "^1.55.0",
         "dotenv": "^17.2.1",
         "eslint": "^9.34.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.1.5",
         "prettier": "^3.6.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.17"
       },
       "peerDependencies": {
         "@nebula.js/stardust": "^5.17.0"
@@ -3974,6 +3976,77 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
@@ -4863,6 +4936,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -5649,6 +5735,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+      "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6085,6 +6184,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyperdyperid": {
@@ -6841,6 +6956,193 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lint-staged": {
+      "version": "16.1.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.5.tgz",
+      "integrity": "sha512-uAeQQwByI6dfV7wpt/gVqg+jAPaSp8WwOA8kKC/dv1qw14oGpnpAisY65ibGHUGDUv0rYaZ8CAJZ/1U8hUvC2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.5.0",
+        "commander": "^14.0.0",
+        "debug": "^4.4.1",
+        "lilconfig": "^3.1.3",
+        "listr2": "^9.0.1",
+        "micromatch": "^4.0.8",
+        "nano-spawn": "^1.0.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.2",
+        "yaml": "^2.8.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/chalk": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
+      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/lint-staged/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.2.tgz",
+      "integrity": "sha512-VVd7cS6W+vLJu2wmq4QmfVj14Iep7cz4r/OWNk36Aq5ZOY7G8/BfCrQFexcwB1OIxB3yERiePfE/REBjEFulag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -6983,6 +7285,222 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+      "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
+      "integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+      "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+      "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+      "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/lower-case": {
@@ -7189,6 +7707,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7243,6 +7774,19 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/nano-spawn": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.2.tgz",
+      "integrity": "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7780,6 +8324,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -9034,6 +9591,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.44.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
@@ -9677,6 +10241,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -9868,6 +10475,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-hash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qs-ext-jump-start",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qs-ext-jump-start",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "SEE LICENSE IN license.txt",
       "devDependencies": {
         "@eslint/js": "^9.34.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "playwright",
     "template"
   ],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "SEE LICENSE IN license.txt",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     }
   ],
   "scripts": {
-    "lint": "eslint src",
+    "prepare": "husky",
+    "lint": "eslint -c eslint.config.mjs src test",
+    "lint-staged": "lint-staged",
     "build": "nebula build",
     "serve": "nebula serve",
     "test": "playwright test",
@@ -41,7 +43,7 @@
     "package": "nebula sense --meta src/meta.json"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.17"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",
@@ -52,10 +54,17 @@
     "@playwright/test": "^1.55.0",
     "dotenv": "^17.2.1",
     "eslint": "^9.34.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.1.5",
     "prettier": "^3.6.2"
   },
   "peerDependencies": {
     "@nebula.js/stardust": "^5.17.0"
+  },
+  "lint-staged": {
+    "*.{js,jsx,mjs,cjs}": [
+      "eslint -c eslint.config.mjs --fix"
+    ]
   },
   "files": [
     "dist"

--- a/test/helpers/test-utils.js
+++ b/test/helpers/test-utils.js
@@ -813,6 +813,8 @@ async function getExtensionState(page) {
 }
 
 module.exports = {
+  // Expose WAIT buckets for consistent timing across tests
+  WAIT,
   configureExtension,
   cleanupExtensionConfiguration,
   triggerSelectionMode,

--- a/test/helpers/test-utils.js
+++ b/test/helpers/test-utils.js
@@ -4,8 +4,6 @@
  * supernova during Playwright runs. Focuses on robust selectors and timing.
  */
 
-/* eslint-disable no-console */
-
 // ---------------------------------------------------------------------------
 // Shared constants & tiny utilities
 // ---------------------------------------------------------------------------
@@ -526,9 +524,10 @@ async function resetPropertiesToEmptyJson(page) {
       // Attempt to clear and type {}
       try {
         await inputFound.click({ force: true });
-        // Support both CodeMirror/Monaco by sending select-all and backspace
-        await page.keyboard.press('Control+A').catch(() => {});
-        await page.keyboard.press('Meta+A').catch(() => {});
+        // Support both CodeMirror/Monaco by sending platform-aware select-all and backspace
+        const isMac = await page.evaluate(() => navigator.platform.includes('Mac'));
+        const selectAllCombo = isMac ? 'Meta+A' : 'Control+A';
+        await page.keyboard.press(selectAllCombo).catch(() => {});
         await page.keyboard.press('Backspace').catch(() => {});
         await page.keyboard.type('{}', { delay: 10 });
         // Brief pause so the change is visible in headed mode

--- a/test/states/responsiveness.test.js
+++ b/test/states/responsiveness.test.js
@@ -1,5 +1,5 @@
 const { expect, test } = require('@playwright/test');
-const { configureExtension, triggerSelectionMode, clearAllSelections } = require('../helpers/test-utils');
+const { configureExtension, triggerSelectionMode, clearAllSelections, WAIT } = require('../helpers/test-utils');
 const commonTests = require('./common.test');
 
 module.exports = {
@@ -21,7 +21,7 @@ module.exports = {
 
     for (const vp of viewports) {
       await page.setViewportSize(vp);
-      await page.waitForTimeout(200);
+      await page.waitForTimeout(WAIT.SHORT);
 
       const root = page.locator(content);
       const noData = page.locator(content + ' .no-data');
@@ -55,7 +55,7 @@ module.exports = {
       dimensions: ['Dim1'],
       measures: [{ field: 'Expression1', aggregation: 'Sum' }],
     });
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(WAIT.LONG);
     const state = await commonTests.getExtensionState(page, content);
     if (!configured || state !== 'extension-container') {
       // Gate: requires data state; if not available, document and exit as a stub.
@@ -65,7 +65,7 @@ module.exports = {
 
     for (const vp of viewports) {
       await page.setViewportSize(vp);
-      await page.waitForTimeout(250);
+      await page.waitForTimeout(WAIT.SHORT);
 
       const root = page.locator(content);
       const table = page.locator(content + ' table.data-table');
@@ -97,7 +97,7 @@ module.exports = {
       dimensions: ['Dim1'],
       measures: [{ field: 'Expression1', aggregation: 'Sum' }],
     });
-    await page.waitForTimeout(300);
+    await page.waitForTimeout(WAIT.SHORT);
     const state = await commonTests.getExtensionState(page, content);
     if (!configured || state !== 'extension-container') {
       // Gate: requires data state; if not available, document and exit as a stub.
@@ -117,7 +117,7 @@ module.exports = {
 
     for (const vp of viewports) {
       await page.setViewportSize(vp);
-      await page.waitForTimeout(250);
+      await page.waitForTimeout(WAIT.SHORT);
 
       // No horizontal overflow inside container while in selection
       const rootMetrics = await page.locator(content).evaluate((el) => ({ sw: el.scrollWidth, cw: el.clientWidth }));

--- a/test/states/robustness.test.js
+++ b/test/states/robustness.test.js
@@ -1,5 +1,5 @@
 const { expect, test } = require('@playwright/test');
-const { configureExtension, triggerSelectionMode, clearAllSelections } = require('../helpers/test-utils');
+const { configureExtension, triggerSelectionMode, clearAllSelections, WAIT } = require('../helpers/test-utils');
 const commonTests = require('./common.test');
 
 // Extract magic numbers as named constants for clarity/maintainability
@@ -19,7 +19,7 @@ module.exports = {
       dimensions: ['Dim1'],
       measures: [{ field: 'Expression1', aggregation: 'Sum' }],
     });
-    await page.waitForTimeout(300);
+    await page.waitForTimeout(WAIT.SHORT);
     const state = await commonTests.getExtensionState(page, content);
     if (!configured || state !== 'extension-container') {
       // Gate: requires data state; if not available, document and exit as a stub.
@@ -70,7 +70,7 @@ module.exports = {
       dimensions: ['Dim1'],
       measures: [{ field: 'Expression1', aggregation: 'Sum' }],
     });
-    await page.waitForTimeout(300);
+    await page.waitForTimeout(WAIT.SHORT);
     const state = await commonTests.getExtensionState(page, content);
     if (!configured || state !== 'extension-container') {
       // Gate: requires data state; if not available, document and exit as a stub.
@@ -119,7 +119,7 @@ module.exports = {
       dimensions: ['Dim1'],
       measures: [{ field: 'Expression1', aggregation: 'Sum' }],
     });
-    await page.waitForTimeout(300);
+    await page.waitForTimeout(WAIT.SHORT);
     const state = await commonTests.getExtensionState(page, content);
     if (!configured || state !== 'extension-container') {
       // Gate: requires data state; if not available, document and exit as a stub.
@@ -187,7 +187,7 @@ module.exports = {
         if (!(await third.evaluate((el) => document.activeElement === el).catch(() => false))) {
           await third.click({ force: true }).catch(() => {});
         }
-        await page.waitForTimeout(60);
+        await page.waitForTimeout(WAIT.TINY);
       }
     }
 
@@ -211,7 +211,7 @@ module.exports = {
     // Try entering selection once before reload
     await clearAllSelections(page).catch(() => {});
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
-    await page.waitForTimeout(200);
+    await page.waitForTimeout(WAIT.SHORT);
     await triggerSelectionMode(page);
 
     // Reload page and ensure extension renders to a valid state

--- a/test/states/robustness.test.js
+++ b/test/states/robustness.test.js
@@ -2,6 +2,10 @@ const { expect, test } = require('@playwright/test');
 const { configureExtension, triggerSelectionMode, clearAllSelections } = require('../helpers/test-utils');
 const commonTests = require('./common.test');
 
+// Extract magic numbers as named constants for clarity/maintainability
+const THRASH_ITERATIONS = 5;
+const SHORT_DELAY_MS = 40;
+
 module.exports = {
   /**
    * Asserts re-renders do not duplicate containers/tables or surface errors.
@@ -39,13 +43,13 @@ module.exports = {
     const b = cells.nth(secondIdx);
     await a.scrollIntoViewIfNeeded();
     await b.scrollIntoViewIfNeeded();
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < THRASH_ITERATIONS; i++) {
       await a.focus();
       await page.keyboard.press('Enter');
-      await page.waitForTimeout(40);
+      await page.waitForTimeout(SHORT_DELAY_MS);
       await b.focus();
       await page.keyboard.press('Enter');
-      await page.waitForTimeout(40);
+      await page.waitForTimeout(SHORT_DELAY_MS);
     }
 
     // Validate single container and table, and no error messages

--- a/test/states/selection.test.js
+++ b/test/states/selection.test.js
@@ -1,5 +1,5 @@
 const { expect, test } = require('@playwright/test');
-const { triggerSelectionMode, configureExtension, clearAllSelections } = require('../helpers/test-utils');
+const { triggerSelectionMode, configureExtension, clearAllSelections, WAIT } = require('../helpers/test-utils');
 const commonTests = require('./common.test');
 
 /**
@@ -80,7 +80,7 @@ module.exports = {
       console.error('Failed to clear selections:', err);
     });
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(WAIT.MED);
 
     const state = await commonTests.getExtensionState(page, content);
     if (state !== 'extension-container') {
@@ -119,7 +119,7 @@ module.exports = {
   async shouldToggleSameCellOff(page, content) {
     await clearAllSelections(page).catch(() => {});
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(WAIT.MED);
 
     const state = await commonTests.getExtensionState(page, content);
     if (state !== 'extension-container') {
@@ -157,7 +157,7 @@ module.exports = {
   async shouldMultiSelectAndThenExit(page, content) {
     await clearAllSelections(page).catch(() => {});
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(WAIT.MED);
     const state = await commonTests.getExtensionState(page, content);
     if (state !== 'extension-container') {
       test.info().annotations.push({ type: 'skip', description: `Data state not reachable (${state})` });
@@ -219,7 +219,7 @@ module.exports = {
   async shouldSupportKeyboardToggle(page, content) {
     await clearAllSelections(page).catch(() => {});
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(WAIT.MED);
 
     const state = await commonTests.getExtensionState(page, content);
     if (state !== 'extension-container') {
@@ -265,7 +265,7 @@ module.exports = {
   async shouldConfirmSelectionsByClickingOutside(page, content) {
     await clearAllSelections(page).catch(() => {});
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(WAIT.MED);
 
     const state = await commonTests.getExtensionState(page, content);
     if (state !== 'extension-container') {
@@ -291,7 +291,7 @@ module.exports = {
 
     // Wait for selection mode to exit and layout to update
     await expect(page.locator(content + ' .extension-container.in-selection')).toHaveCount(0);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(WAIT.LONG);
 
     // Verify all rows show only the selected value
     const dimCells = await page.$$(content + ' table.data-table tbody tr td.dim-cell');
@@ -311,7 +311,7 @@ module.exports = {
   async shouldConfirmSelectionsByButton(page, content) {
     await clearAllSelections(page).catch(() => {});
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(WAIT.MED);
 
     const state = await commonTests.getExtensionState(page, content);
     if (state !== 'extension-container') {
@@ -362,7 +362,7 @@ module.exports = {
 
     // Wait for selection mode to exit and layout to update
     await expect(page.locator(content + ' .extension-container.in-selection')).toHaveCount(0);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(WAIT.LONG);
 
     // Verify all rows show only the selected values
     const dimCells = await page.$$(content + ' table.data-table tbody tr td.dim-cell');

--- a/test/states/selection.test.js
+++ b/test/states/selection.test.js
@@ -76,7 +76,9 @@ module.exports = {
    * @returns {Promise<void>}
    */
   async shouldEnterSelectionWithPlainClick(page, content) {
-    await clearAllSelections(page).catch((err) => { console.error('Failed to clear selections:', err); });
+    await clearAllSelections(page).catch((err) => {
+      console.error('Failed to clear selections:', err);
+    });
     await configureExtension(page, { dimensions: ['Dim1'], measures: [{ field: 'Expression1', aggregation: 'Sum' }] });
     await page.waitForTimeout(800);
 
@@ -92,7 +94,12 @@ module.exports = {
       return;
     }
     const firstElem = await firstCellHandle.getAttribute('data-q-elem');
-    await firstCellHandle.click({ force: true });
+    // Prefer default actionability; fallback to force if transient overlays/backdrops interfere.
+    try {
+      await firstCellHandle.click();
+    } catch {
+      await firstCellHandle.click({ force: true });
+    }
     // Wait for selection mode to be active and DOM to re-render
     await page.waitForSelector(content + ' .extension-container.in-selection', { timeout: 3000 });
 
@@ -127,7 +134,11 @@ module.exports = {
     }
     const firstElem = await firstCellHandle.getAttribute('data-q-elem');
     const firstCell = page.locator(`${content} [data-q-elem="${firstElem}"]`);
-    await firstCellHandle.click({ force: true });
+    try {
+      await firstCellHandle.click();
+    } catch {
+      await firstCellHandle.click({ force: true });
+    }
     await page.waitForSelector(content + ' .extension-container.in-selection', { timeout: 3000 });
     await expect(firstCell).toHaveClass(/local-selected/);
     // Toggle off
@@ -163,16 +174,32 @@ module.exports = {
     const loc0 = page.locator(`${content} [data-q-elem="${elem0}"]`);
     const loc1 = page.locator(`${content} [data-q-elem="${elem1}"]`);
 
-    await cells[0].click({ force: true });
+    try {
+      await cells[0].click();
+    } catch {
+      await cells[0].click({ force: true });
+    }
     await page.waitForSelector(content + ' .extension-container.in-selection', { timeout: 3000 });
-    await loc1.click({ force: true });
+    try {
+      await loc1.click();
+    } catch {
+      await loc1.click({ force: true });
+    }
 
     await expect(loc0).toHaveClass(/local-selected/);
     await expect(loc1).toHaveClass(/local-selected/);
 
     // Toggle both off
-    await loc0.click({ force: true });
-    await loc1.click({ force: true });
+    try {
+      await loc0.click();
+    } catch {
+      await loc0.click({ force: true });
+    }
+    try {
+      await loc1.click();
+    } catch {
+      await loc1.click({ force: true });
+    }
 
     await expect(loc0).not.toHaveClass(/local-selected/);
     await expect(loc1).not.toHaveClass(/local-selected/);


### PR DESCRIPTION
Why

Protect main by requiring local lint and tests before commits.
Modernize tooling (ESLint v9 flat config, Husky) and reduce test flakiness.
Align metadata/docs with upstream and current practices.
What changed

Tooling and policies
Migrated to ESLint v9 flat config; updated npm scripts and ignores.
Added Husky + lint-staged; pre-commit runs lint only.
.aiconfig policies:
No commit without running tests locally (Playwright reporter=list).
No commit without running lint.
If [package.json](vscode-file://vscode-app/c:/Users/BMD/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) changes: require npm install and stage the lockfile.
Set engines to Node >= 20.17; corrected repository metadata to QlikSenseStudios.
Tests
Normalized literal waits to shared WAIT buckets; actionability-first interactions.
Stabilized selectors; platform-aware select-all; DRY’d helpers.
Source
Replaced container.__localData with WeakMaps to avoid leaks.
Extracted cleanup/reset helpers; updated selection flow to avoid race conditions.
Docs and release
Updated README and docs (removed slowMo mentions, testing guidance for list reporter).
Added CHANGELOG entry for 0.4.1; pruned TODO.
Bumped version to 0.4.1; updated lockfile.
Verification

Lint passes locally.
Playwright test suite passes with reporter=list.
Pre-commit hook runs lint only; .aiconfig blocks commits if tests/lint haven’t been run.
Breaking changes

None. Note: requires Node >= 20.17.