### PR TITLE
chore: rewrite initialization command and align .ai-toolbox system fi…

### DIFF
--- a/.ai-toolbox/README.md
+++ b/.ai-toolbox/README.md
@@ -1,150 +1,52 @@
-# AI Project Context Management System
+# AI Context System
 
-A flexible, hierarchical context management system for AI agents that supports any type of project without assumptions or opinions.
+Hierarchical context management for AI agents working on this Qlik Sense extension project.
 
-## Getting Started with Your Project
+**AI Agent Entry Point**: Load `context.global.md` at the start of every session.
 
-**Quick Setup**: See [docs/Getting Started.md](docs/Getting%20Started.md) for the simple 3-step process.
-
-**What This System Provides**: Environment detection, preference collection, and hierarchical context management that works with any AI agent system.
+```
+Always start by loading context from './.ai-toolbox/context.global.md' and follow the established maintenance rules automatically.
+```
 
 ---
 
-## Context Loading Patterns
+## Context Loading Paths
 
-```bash
-# Core context always loaded first
-context.global.md + context.local.md (auto-merged)
-
-# Project initialization
-context.global.md → commands/initialization.md
-
-# Project status check
-context.global.md → context.state.md
+```
+context.global.md + context.local.md     # core — always loaded
+context.global.md -> context.state.md     # project status
+context.global.md -> commands/initialization.md   # first-time setup
 ```
 
-*See the docs/ guides for extending domains, patterns, tool contexts, and commands as your project grows.*
+## System Structure
 
-## System Features
-
-### Built-In Initialization
-- **Automatic Setup**: Local environment detection and context file creation
-- **User Preference Collection**: Guided configuration of development workflows  
-- **Zero Configuration**: Ready-to-use context system from first project use
-- **Cross-Platform**: Supports Windows, macOS, and Linux development environments
-
-See [docs/Getting Started.md](docs/Getting%20Started.md) for complete setup process.
-
-### Intelligent Maintenance
-- **Real-Time Updates**: Environment and capability changes automatically detected
-- **Preference Persistence**: User workflows maintained across updates
-- **Documentation Sync**: Project status automatically updated across all files
-
-See [docs/Local Context.md](docs/Local%20Context.md) for local environment management details.
-
-### Project Backlog
-- **Cross-Session Tracking**: Upcoming work and recently completed items persist across sessions
-- **Collaboration Ready**: Dependency and parallel safety signals for team coordination
-- **AI-Maintained**: Completed items automatically mirrored to project state and aged out per configurable criteria
-- **Prompt-Driven**: Add items, suggest next steps, and mark completions via natural language
-
-See [docs/Backlog.md](docs/Backlog.md) for prompt examples and backlog management guidance.
+```
+.ai-toolbox/
+├── context.global.md        # START HERE — central routing and maintenance rules
+├── context.local.md         # personal environment and preferences (not in version control)
+├── context.state.md         # current project status
+├── context.backlog.md       # upcoming work and recently completed items
+├── commands/                # operation patterns (initialization, development, project, context)
+├── docs/                    # documentation about this context system
+├── project/                 # project overview and quality standards
+├── domains/                 # domain-specific contexts
+│   ├── qlik-extension.md    # Nebula.js, state management, test infrastructure
+│   └── research.md          # example — add more as needed
+├── patterns/                # reusable patterns (setup.md example)
+└── tools/                   # tool-specific contexts
+    └── git.md               # Git conventions, PR methodology, milestone workflow
+```
 
 ## Core Principles
 
-- **Minimal Loading**: Load only what you need
-- **Domain Agnostic**: No assumptions about project type  
-- **DRY Information**: Single source of truth
-- **Minimal Context**: Essential information only
-
-## Context System Structure
-
-**Before Initialization**:
-```
-project-space/
-├── .ai-toolbox/         # AI context management system
-├── .sandbox/            # Work area for references (gitignored)
-├── README.md            # Project state documentation
-└── .gitignore           # Version control patterns
-```
-
-**After Initialization**:
-```
-your-project/
-├── .ai-toolbox/         # AI context system
-├── .sandbox/            # Work area for references (gitignored)
-├── */*                  # Your project structure defined by you
-├── README.md            # Your project documentation
-└── .gitignore           # Version control patterns
-```
-
-**AI Context System Structure**:
-```
-.ai-toolbox/
-├── docs/                # 📚 System documentation  
-│   ├── Getting Started.md # Simple 3-step user guide
-│   ├── Local Context.md # Local environment guide
-│   ├── Backlog.md       # Backlog usage guide
-│   ├── Project Context.md # Project overview and standards guide
-│   ├── Domains.md       # Domain context guide
-│   ├── Patterns.md      # Patterns usage guide
-│   ├── Tools.md         # Tool contexts guide
-│   └── Commands.md      # Commands usage guide
-├── context.local.md     # User environment basics (minimal personal preferences)
-├── context.global.md    # 🚀 START HERE - Central routing
-├── context.state.md     # Current project status
-├── context.backlog.md   # Project backlog and recently completed work
-├── commands/            # Available operations
-├── project/             # Project context (overview, standards)
-├── domains/             # Domain contexts (research.md example provided)
-├── patterns/            # Reusable patterns (setup.md example provided)
-└── tools/               # Tool-specific contexts (git.md example provided)
-```
-
-## Usage Examples
-
-*Note: context.local.md is automatically merged with context.global.md in all scenarios*
-
-### Common Paths
-```
-context.global.md → context.state.md (project status)
-context.global.md → commands/initialization.md (setup new project)
-```
-
-### With Domain, Pattern, and Tool Contexts
-- Domain-specific contexts for specialized project types (research.md example provided)
-- Reusable patterns for common development approaches (setup.md example provided)
-- Tool-specific contexts for your team's development tools (git.md example provided)
-
-See [docs/Domains.md](docs/Domains.md) for domain context patterns and how to add new domains.
-See [docs/Patterns.md](docs/Patterns.md) for pattern usage and how to add new patterns.
-See [docs/Tools.md](docs/Tools.md) for tool context usage and how to add new tool contexts.
-See [docs/Commands.md](docs/Commands.md) for command context usage and how to extend commands.
+- **Minimal loading**: Load only what the task requires
+- **DRY**: Single source of truth — no duplicated information except approved mirrors
+- **Current state only**: context.state.md reflects the present; history lives in context.backlog.md
+- **Agent agnostic**: No agent-specific references except in context.local.md
 
 ## Growing the System
 
-Add contexts as needed following DRY principles and updating context.global.md routing.
-
-## AI Agent Integration
-
-### Example Integration
-```
-Your Agent Config → ai-toolbox/context.global.md → [context hierarchy]
-```
-
-### AI Agent Requirements
-- **Documentation Sync**: Automatically update documentation when modifying routing
-- **DRY Maintenance**: Eliminate redundancies across context files
-- **Rule Application**: Follow all maintenance rules automatically
-
-## Philosophy
-
-This system grows organically with your needs while maintaining:
-- ✅ Flexibility for any project type
-- ✅ Minimal context loading overhead
-- ✅ Information consistency (DRY)
-- ✅ Clear navigation paths
-- ✅ AI agent collaboration support
+Add domain, pattern, or tool contexts as needed. See the guides in `docs/` for how to extend each area. Update `context.global.md` Available Contexts when adding new files so agents can discover them.
 
 ---
-**AI context management system ready for any project type.**
+*See `docs/` for human-readable guides. See `context.global.md` for maintenance rules.*

--- a/.ai-toolbox/commands/initialization.md
+++ b/.ai-toolbox/commands/initialization.md
@@ -1,7 +1,7 @@
 # Project Initialization Command
 
 **Trigger**: When `context.local.md` is missing during context loading
-**Purpose**: Complete workspace system setup to an operational project
+**Purpose**: Set up this Qlik Sense extension template for your extension project
 
 ## Detection Pattern
 
@@ -9,121 +9,84 @@ If loading `context.global.md` and `context.local.md` doesn't exist → initiate
 
 ## Initialization Sequence
 
-### Environment Detection
-**Auto-discover**:
+### Step 1 — Environment Detection
+
+Auto-detect and record:
 - Operating system (Windows, macOS, Linux)
 - Primary shell (Bash, PowerShell, Zsh)
 - Workspace root path
-- Current date/timezone
+- Current date
 
-**Capability scan**:
-- Git availability and configuration
-- Code editors (VS Code, etc.)
-- Runtime environments (Node.js, Python, Java)
-- Package managers (npm, pip, gem)
-- Development tools (Docker, databases)
+### Step 2 — Extension Identity
 
-### User Preference Collection
-**Personal workflow preferences**:
-- Change management style (iterative vs. batch)
-- Communication style with AI agents (e.g., verbose explanations vs. concise output)
+Collect from user:
+- **Extension name**: The name of your extension — used in `package.json`, `src/meta.json`, `README.md`, and the packaged output folder
+- **Description**: What does this extension do? What problem does it solve?
+- **Target platform**: Qlik Cloud, Qlik Sense Enterprise, or both
 
-**Project backlog preferences**:
-- Completed item age-out criteria (default applied if not specified: 30 days OR 3 newest per contributor, whichever comes first)
-  - Option A: After N days
-  - Option B: Keep only N newest per contributor
-  - Option C: After N days OR keep only N newest per contributor, whichever comes first
-- Update the **Active criteria** line in context.backlog.md with the chosen or default criteria
-- Inform user they can change this at any time — see [docs/Backlog.md](../docs/Backlog.md)
+### Step 3 — Work Style Preferences
 
-**Development environment preferences**:
-- Preferred editor/IDE setup
-- Terminal and shell preferences
-- Package manager choices
-- Testing and debugging approaches
+Collect from user:
+- **Contributor name**: Used to attribute completed work in backlog and state context
+- **Work style**: How should the AI agent communicate and pace work? (e.g., one step at a time with explicit approval, verbose explanations vs. concise output)
+- **Change management**: Iterative (small focused changes) or batch (larger grouped changes)
 
-**File system preferences**:
-- Cross-platform path handling
-- Text encoding preferences
-- Line ending management
-- File naming conventions
+### Step 4 — Local Context Creation
 
-**Local tool configuration**:
-- Git user configuration
-- IDE/editor settings
-- Shell aliases and shortcuts
-- Environment variables
+Generate `context.local.md` with:
+- **Environment Basics** (auto-detected): OS, shell, workspace root, date initialized
+- **User Preferences** (from Step 3): contributor name, work style, change management style
+- Clearly marked `<!-- USER EDITABLE SECTION -->` boundaries so automated updates never overwrite personal settings
+- Note to user: this file is not committed to version control — it is personal to this workspace
 
-### Local Context Creation
-*Minimal context following system rules*
+### Step 5 — Apply Extension Identity
 
-**Generate context.local.md** with:
-1. **Environment Basics** (auto-detected)
-   - OS, shell, workspace root, current date
-2. **Available Tools** (auto-detected)
-   - Detected development tools and capabilities
-3. **User Preferences Section** (user editable area)
-   - Minimal personal settings
-   - Clear USER EDITABLE SECTION markers to protect from automatic updates
+Apply the name and description from Step 2 to:
+- **`package.json`**: Update `name` and `description` fields
+- **`src/meta.json`**: Update `name` field
+- **`README.md`**: Replace the template title, description, and purpose with the extension's name and purpose; replace the Quick Start section with extension-specific setup steps (remove "Use this template" and AI initialization instructions — those are complete; retain `npm install`, environment setup links, `npm run serve`); remove the Contributing section (references `CONTRIBUTING.md` which is deleted in Step 6)
+- **`project/overview.md`**: Populate mission, goals, and scope from the collected extension purpose
 
-**User Customization Setup**:
-- Explain manual editing options
-- Provide prompt-based update examples
-- Ensure user understands this file is not in version control
-- Guide user through personalizing their development preferences
+### Step 6 — Remove Template Artifacts
 
-**Integration**:
-- Auto-merge with global routing for all context operations
-- Validate context loading paths
-- Initialize preference persistence system
+These files describe the template's own development process and are not relevant to extension development:
+- **Delete `CONTRIBUTING.md`**: Describes contributing to the template, not to your extension project
+- **Delete `.ai-toolbox/context.development.md`**: Template development rules; not applicable once initialized
+- **Delete `.ai-toolbox/docs/Getting Started.md`**: Initialization guide; superseded by the initialized `README.md`
 
-### Project Customization
-**Structure setup**:
-- Create directories based on project type
-- Initialize domain contexts if applicable — see [docs/Domains.md](../docs/Domains.md) for domain context patterns
-- Apply reusable patterns if applicable — see [docs/Patterns.md](../docs/Patterns.md) for pattern usage
-- Configure tool contexts if applicable — see [docs/Tools.md](../docs/Tools.md) for tool context conventions
-- Configure tool-specific settings
+### Step 7 — Qlik Environment Setup
 
-**Documentation**:
-- Update root README with project info
-- Populate `project/overview.md` with project name, mission, goals, and scope gathered during setup
-- Populate `project/standards.md` with quality standards based on user's development preferences
+Direct the user to the appropriate setup guide based on the target platform from Step 2:
+- Qlik Cloud → `docs/QLIK_CLOUD_SETUP.md`
+- Qlik Sense Enterprise → `docs/QLIK_ENTERPRISE_SETUP.md`
+- Both → complete both guides
 
-### Version Control
-**If Git detected**:
-- Initialize repository (if needed)
-- Create .gitignore for detected technologies
-- Set up initial commit
-- Configure user Git settings
+Confirm the user has a test application and connection string ready before they run `npm test`.
 
-### Validation & Handoff
-**System check**:
-- Verify context file linking
-- Test context loading paths
-- Confirm capability detection
-- Validate user preferences active
+### Step 8 — AI Agent Setup
 
-**Documentation sync**:
-- Update project status in README files
-- Generate quick start instructions
-- Create usage examples
+Record in `context.local.md` and communicate clearly to the user:
 
-**Completion**:
-- Report initialization summary
-- **Remove System Development Context**: Delete .ai-toolbox/context.development.md (not needed in project mode)
-- **AI Agent Setup**: Add prompt instruction: "Load context from './.ai-toolbox/context.global.md' and follow maintenance rules automatically"
-- Provide next steps
+**Essential prompt for every session**:
+```
+Always start by loading context from './.ai-toolbox/context.global.md' and follow the established maintenance rules automatically.
+```
 
-## User Configuration  
-**Essential Prompt**: `"Always start by loading context from './.ai-toolbox/context.global.md' and follow the established maintenance rules automatically."`
+The `.ai-toolbox/` directory is the single source of truth for all project context. The AI agent loads domain context (`domains/qlik-extension.md`), project state (`context.state.md`), and user preferences (`context.local.md`) from there automatically. Add this prompt to your AI agent workspace configuration, session opener, or instructions file.
+
+### Step 9 — Validation & Handoff
+
+- Confirm `context.local.md` created and populated correctly
+- Confirm `CONTRIBUTING.md` and `context.development.md` removed
+- Confirm `project/overview.md` reflects the extension's purpose
+- Report what was completed and what still requires manual action (e.g., git remote configuration, Qlik environment setup)
+- Provide the next steps: set up Qlik environment, run `npm install`, run `npm run serve` to verify the template extension loads
 
 ## Error Handling
 
-**Graceful degradation**: Continue if non-critical capabilities missing
-**Fallbacks**: Provide alternatives for missing tools
-**Recovery**: Offer re-initialization for failed setups
+**Skipped steps**: If the user skips a collection step (e.g., doesn't know the extension name yet), leave a clear `[TODO: update this]` placeholder in the affected file and note which files need manual update
+**Graceful degradation**: Continue if non-critical steps fail; flag for manual completion
 
 ---
 
-*This command creates a fully operational, environment-aware project workspace ready for immediate development.*
+*After initialization, `context.development.md` has been removed. Load all future context from `context.global.md`.*

--- a/.ai-toolbox/context.development.md
+++ b/.ai-toolbox/context.development.md
@@ -72,7 +72,6 @@ Dependabot handles direct dependency version bumps (`package.json` ranges). The 
 ## Upcoming Work
 *Forward-looking only. No history. Remove items when complete — do not mark or annotate them.*
 
-- **Initialization command review** (branch: `chore/initialization`): Review and update `commands/initialization.md` for correctness and completeness; ensure `CONTRIBUTING.md` is removed or replaced during initialization (it describes template contribution, not extension development); validate all initialization steps work cleanly in a fresh template repo; consider a separate contributing initialization command that prompts contributors to record their fork/upstream topology in `context.local.md` (upstream = `QlikSenseStudios`, fork = contributor's remote) so GitHub URL references stay correct throughout development
 - **Restore Playwright testing coverage** (branch: `fix/playwright-coverage`): Investigate and resolve the 2 skipped tests caused by Nebula Hub DOM drift with latest `@nebula.js/cli-serve`; restore full test suite to passing
 
 ### Optional Enhancements

--- a/.ai-toolbox/context.global.md
+++ b/.ai-toolbox/context.global.md
@@ -2,7 +2,7 @@
 
 **AI Agent Entry Point**: Start here for all context loading. `context.local.md` automatically merged.
 
-**Initialization Required**: If `context.local.md` doesn't exist, this is a new project - follow initialization workflow in `./commands/initialization.md`.
+**Initialization Required**: If `context.local.md` doesn't exist, this workspace has not been initialized yet — the user has set up from the template but has not run the initialization workflow. Follow `./commands/initialization.md` before proceeding.
 
 ## Definitions
 - **Project**: The current project using this context management system
@@ -13,7 +13,7 @@
 ## Hierarchy Levels
 1. **Core**: context.global.md + context.local.md (auto-merged, generated if missing)
 2. **Operational**: context.state.md + available commands/
-3. **Domain**: domains/ (research.md example provided) + patterns/ (setup.md example provided) + tools/ (git.md example provided)
+3. **Domain**: domains/ (qlik-extension.md primary + research.md as additional example) + patterns/ (setup.md example provided) + tools/ (git.md — Git conventions and PR workflow)
 4. **Project**: project/ (pre-configured stubs — populate with your project details)
 
 ## Standard Loading Paths

--- a/.ai-toolbox/context.state.md
+++ b/.ai-toolbox/context.state.md
@@ -23,21 +23,20 @@ Current operational status for AI agents. Machine-readable only.
 - **Commands**: initialization.md (project setup), context.md (context management — includes List Commands), development.md (development workflows), project.md (project management)
 - **Documentation**: Getting Started.md, Local Context.md, Backlog.md, Project Context.md, Domains.md, Patterns.md, Tools.md, Commands.md
 - **Project Context**: overview.md, standards.md
-- **Domain Contexts**: research.md (example — add more as needed)
+- **Domain Contexts**: qlik-extension.md (Qlik Sense extension development), research.md (example — add more as needed)
 - **Pattern Contexts**: setup.md (example — add more as needed)
-- **Tool Contexts**: git.md (example — add more as needed)
+- **Tool Contexts**: git.md (Git conventions and PR workflow)
 - **Core Context**: System README.md
 
 ## Current Capabilities
-- System ready for project initialization
-- Project initialization workflow  
-- User preference collection and persistence
-- Local environment detection and adaptation
-- Context-aware development support
+- Project initialization workflow
+- Context-aware Qlik extension development support
+- Git conventions, PR methodology, and milestone workflow
+- Qlik Sense / Nebula.js domain context
 
 ## Workspace Structure
 ```
-ai-project-workspace/            # Project root
+<your-extension>/                # Project root
 ├── .ai-toolbox/                 # Context management system
 │   ├── context.global.md        # Clean project-focused routing
 │   ├── context.state.md         # Project status tracking

--- a/.ai-toolbox/docs/Domains.md
+++ b/.ai-toolbox/docs/Domains.md
@@ -35,15 +35,17 @@ Keep domain contexts focused on the domain — not on your specific project. Pro
 
 ---
 
-## Example Domain: research.md
+## Included Domain: qlik-extension.md
 
-[domains/research.md](../domains/research.md) is a working example showing the structure. It covers research and discovery workflows with patterns, tools, and cross-references to related contexts.
+[domains/qlik-extension.md](../domains/qlik-extension.md) is the primary domain context for this template. It covers the Nebula.js Supernova API, state management patterns, safe DOM practices, and the test infrastructure. Load it when working on extension source code, property panel configuration, or tests.
+
+[domains/research.md](../domains/research.md) is an additional example showing the structure for adding other domain types.
 
 ---
 
 ## Adding a New Domain
 
-1. Create `domains/{name}.md` following the structure of [domains/research.md](../domains/research.md)
+1. Create `domains/{name}.md` following the structure of [domains/qlik-extension.md](../domains/qlik-extension.md) or [domains/research.md](../domains/research.md)
 2. Add it to the Available Domains list in [domains/README.md](../domains/README.md)
 3. Update [context.global.md](../context.global.md) Available Contexts if you want agents to discover it
 

--- a/.ai-toolbox/docs/Getting Started.md
+++ b/.ai-toolbox/docs/Getting Started.md
@@ -1,47 +1,42 @@
 # Getting Started
 
-Simple 3-step process to set up any project with this AI-enabled workspace system.
+Set up this Qlik Sense extension template for your extension project in three steps.
 
-## Step 1: Get the System
+## Step 1: Create your repository
 
-**From GitHub**: Click "Use this template" → Clone to your workspace  
-**Download**: Download ZIP → Extract to your project folder
+Click **Use this template** on GitHub, or clone and re-point your remote to a new repository.
 
-## Step 2: Initialize Your Project
+## Step 2: Initialize your project
 
 Tell your AI agent:
 ```
-Initialize this project [PROJECT_NAME] for [PROJECT_DESCRIPTION] maintaining the context in './.ai-toolbox/context.global.md'
+Initialize this project maintaining the context in './.ai-toolbox/context.global.md'
 ```
 
-**Example**:
-```
-Initialize this project "Task Manager" for "Personal productivity app with React frontend" maintaining the context in './.ai-toolbox/context.global.md'
-```
+The initialization workflow will walk you through:
+- Extension name, description, and target platform (Qlik Cloud / Enterprise)
+- Your work style and contributor name
+- Applying your extension identity to `package.json`, `src/meta.json`, and `README.md`
+- Removing template-only files (`CONTRIBUTING.md`, `context.development.md`)
+- Pointing you to the right Qlik environment setup guide
 
-## Step 3: Start Building
+## Step 3: Start building
 
-Your project is ready! The AI context system is now active and will:
-- Automatically load your local environment and preferences
-- Apply context management rules passively  
-- Provide context-aware assistance
-
-**AI Agent Setup**: Use this prompt for best results:
+After initialization, use this prompt at the start of every session:
 ```
 Always start by loading context from './.ai-toolbox/context.global.md' and follow the established maintenance rules automatically.
 ```
 
-Just ask for what you need - the context system works in the background.
+The AI agent will automatically load your environment, preferences, and Qlik extension domain context from `.ai-toolbox/`. Add this prompt to your AI agent workspace configuration or session opener so you don't have to repeat it.
 
-**Further customization** (optional, after initialization):
-- Define your project: [Project Context.md](Project%20Context.md)
-- Add domain contexts: [Domains.md](Domains.md)
-- Apply reusable patterns: [Patterns.md](Patterns.md)
-- Configure tool contexts: [Tools.md](Tools.md)
-- Extend command patterns: [Commands.md](Commands.md)
+**Next steps after initialization**:
+- Set up your Qlik environment: `docs/QLIK_CLOUD_SETUP.md` or `docs/QLIK_ENTERPRISE_SETUP.md`
+- Install dependencies: `npm install`
+- Start the dev server: `npm run serve`
+- Run tests: `npm test`
+
+**Optional — extend the context system**:
+- Define project goals and scope: [Project Context.md](Project%20Context.md)
+- Add domain or tool contexts: [Domains.md](Domains.md), [Tools.md](Tools.md)
 - Manage your backlog: [Backlog.md](Backlog.md)
-- Customize your local preferences: [Local Context.md](Local%20Context.md)
-
----
-
-**That's it!** The AI context system handles environment detection, preference collection, and setup automatically.
+- Customize local preferences: [Local Context.md](Local%20Context.md)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@ A Qlik Sense extension template built on Nebula.js. Includes a working selection
 ## Quick Start
 
 1. Click "Use this template" on [GitHub](https://github.com/QlikSenseStudios/qs-ext-jump-start)
-2. Clone and install: `git clone <your-repo> && cd <your-repo> && npm install`
-3. Set up your Qlik environment: [Qlik Cloud](./docs/QLIK_CLOUD_SETUP.md) · [Enterprise](./docs/QLIK_ENTERPRISE_SETUP.md)
-4. Start the development server: `npm run serve`
+2. Clone your new repo and open it in your AI agent
+3. Tell your AI agent:
+   ```
+   Initialize this project maintaining the context in './.ai-toolbox/context.global.md'
+   ```
+   This sets up your extension identity, local context, and removes template-only files.
+4. Install dependencies: `npm install`
+5. Set up your Qlik environment: [Qlik Cloud](./docs/QLIK_CLOUD_SETUP.md) · [Enterprise](./docs/QLIK_ENTERPRISE_SETUP.md)
+6. Start the development server: `npm run serve`
 
 ## What's Included
 


### PR DESCRIPTION
…les for Qlik extension template

Replaces generic system boilerplate across .ai-toolbox with Qlik extension-specific content. The initialization command is now a complete 9-step workflow that walks a new adopter from environment detection through applying extension identity, removing template artifacts, and handing off to Qlik environment setup. Supporting system files are updated to match: qlik-extension.md is established as the primary domain context throughout, the init trigger description is accurate, workspace root labels are correct, and the Getting Started.md guide reflects the actual initialization experience. Root README.md Quick Start includes the AI initialization step as step 3 with the correct prompt. context.development.md removes the now-complete initialization review entry from Upcoming Work.

Files changed:

initialization.md — full rewrite, 9-step Qlik-specific sequence README.md — full rewrite, entry-point prompt first, correct structure diagram context.development.md — initialization command review entry removed from Upcoming Work context.global.md — init trigger wording, domain hierarchy description context.state.md — workspace root label, domain listing, capabilities Domains.md — qlik-extension.md promoted as primary domain .ai-toolbox/docs/Getting Started.md — rewritten for Qlik extension audience README.md — AI initialization step added to Quick Start

## Summary

- What changed and why?
- Link to issue(s) if any

## Checklist

- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
- [x] Docs updated if behavior changed (README/docs/CHANGELOG)

## Notes for reviewers

- Risks, roll-out plan, or anything unusual reviewers should know
