### PR TITLE
Improve CI workflows: smart audit gate and label-driven version bump

### DIFF
--- a/.ai-toolbox/commands/initialization.md
+++ b/.ai-toolbox/commands/initialization.md
@@ -40,22 +40,32 @@ Generate `context.local.md` with:
 - Clearly marked `<!-- USER EDITABLE SECTION -->` boundaries so automated updates never overwrite personal settings
 - Note to user: this file is not committed to version control — it is personal to this workspace
 
-### Step 5 — Apply Extension Identity
+### Step 5 — CI Workflow Decision
+
+The template includes five GitHub Actions workflows in `.github/workflows/`: `build.yml`, `lint.yml`, `audit.yml`, `audit-fix.yml`, and `version-bump.yml`. These are documented in `tools/github-actions.md`.
+
+Ask the user:
+> "The template includes CI workflows for build, lint, dependency auditing, and automatic version bumping on merge. Would you like to keep these as-is, or remove them and implement your own CI strategy?"
+
+- **Keep**: retain all workflows unchanged; remind the user to create the version bump labels (`version:patch`, `version:minor`, `version:major`) in the GitHub repo's Labels settings before the version-bump workflow can read them
+- **Remove**: delete the entire `.github/workflows/` directory; note that the user will need to set up their own CI
+
+### Step 6 — Apply Extension Identity
 
 Apply the name and description from Step 2 to:
 - **`package.json`**: Update `name`, `description`, and `version` fields — reset version to the value collected in Step 2
 - **`src/meta.json`**: Update `name` field
-- **`README.md`**: Replace the template title, description, and purpose with the extension's name and purpose; replace the Quick Start section with extension-specific setup steps (remove "Use this template" and AI initialization instructions — those are complete; retain `npm install`, environment setup links, `npm run serve`); remove the Contributing section (references `CONTRIBUTING.md` which is deleted in Step 6)
+- **`README.md`**: Replace the template title, description, and purpose with the extension's name and purpose; replace the Quick Start section with extension-specific setup steps (remove "Use this template" and AI initialization instructions — those are complete; retain `npm install`, environment setup links, `npm run serve`); remove the Contributing section (references `CONTRIBUTING.md` which is deleted in Step 7)
 - **`project/overview.md`**: Populate mission, goals, and scope from the collected extension purpose
 
-### Step 6 — Remove Template Artifacts
+### Step 7 — Remove Template Artifacts
 
 These files describe the template's own development process and are not relevant to extension development:
 - **Delete `CONTRIBUTING.md`**: Describes contributing to the template, not to your extension project
 - **Delete `.ai-toolbox/context.development.md`**: Template development rules; not applicable once initialized
 - **Delete `.ai-toolbox/docs/Getting Started.md`**: Initialization guide; superseded by the initialized `README.md`
 
-### Step 7 — Qlik Environment Setup
+### Step 8 — Qlik Environment Setup
 
 Direct the user to the appropriate setup guide based on the target platform from Step 2:
 - Qlik Cloud → `docs/QLIK_CLOUD_SETUP.md`
@@ -64,7 +74,7 @@ Direct the user to the appropriate setup guide based on the target platform from
 
 Confirm the user has a test application and connection string ready before they run `npm test`.
 
-### Step 8 — AI Agent Setup
+### Step 9 — AI Agent Setup
 
 Record in `context.local.md` and communicate clearly to the user:
 
@@ -75,10 +85,11 @@ Always start by loading context from './.ai-toolbox/context.global.md' and follo
 
 The `.ai-toolbox/` directory is the single source of truth for all project context. The AI agent loads domain context (`domains/qlik-extension.md`), project state (`context.state.md`), and user preferences (`context.local.md`) from there automatically. Add this prompt to your AI agent workspace configuration, session opener, or instructions file.
 
-### Step 9 — Validation & Handoff
+### Step 10 — Validation & Handoff
 
 - Confirm `context.local.md` created and populated correctly
 - Confirm `CONTRIBUTING.md` and `context.development.md` removed
+- Confirm CI workflows retained or removed per Step 5; if retained, remind user to create version bump labels in GitHub
 - Confirm `project/overview.md` reflects the extension's purpose
 - Report what was completed and what still requires manual action (e.g., git remote configuration, Qlik environment setup)
 - Provide the next steps: set up Qlik environment, run `npm install`, run `npm run serve` to verify the template extension loads

--- a/.ai-toolbox/context.development.md
+++ b/.ai-toolbox/context.development.md
@@ -55,21 +55,6 @@ Any item added to the template must satisfy at least one of these criteria:
 Items that exist solely to support this template's own development process do not qualify and must not be committed to the base template.
 Items specific to the example implementation (`src/` — the example table visualization) are acceptable but must be clearly understood as "example — replace with your own implementation."
 
-## CI — Dependency Audit
-
-Two workflows handle dependency security:
-
-- **`audit.yml`** — gate: runs `npm audit --audit-level=moderate` on every push and PR; fails if any moderate-or-above vulnerability is present
-- **`audit-fix.yml`** — scheduled fix: runs every Monday at 06:00 UTC; applies `npm audit fix` and opens a PR targeting `main` if `package-lock.json` changes
-
-**When a Dependabot PR fails the audit gate:**
-1. Trigger **Audit Fix** manually from the Actions UI
-2. Set `base-branch` to the Dependabot branch name
-3. A `chore/audit-fix` PR opens targeting that branch — merge it
-4. The audit gate on the Dependabot PR passes — merge as normal
-
-Dependabot handles direct dependency version bumps (`package.json` ranges). The audit-fix workflow handles transitive lockfile vulnerabilities. They run on the same day but serve different purposes.
-
 ## Upcoming Work
 *Forward-looking only. No history. Remove items when complete — do not mark or annotate them.*
 

--- a/.ai-toolbox/context.global.md
+++ b/.ai-toolbox/context.global.md
@@ -13,7 +13,7 @@
 ## Hierarchy Levels
 1. **Core**: context.global.md + context.local.md (auto-merged, generated if missing)
 2. **Operational**: context.state.md + available commands/
-3. **Domain**: domains/ (qlik-extension.md primary + research.md as additional example) + patterns/ (setup.md example provided) + tools/ (git.md — Git conventions and PR workflow)
+3. **Domain**: domains/ (qlik-extension.md primary + research.md as additional example) + patterns/ (setup.md example provided) + tools/ (git.md — Git conventions and PR workflow; github-actions.md — CI/CD workflows)
 4. **Project**: project/ (pre-configured stubs — populate with your project details)
 
 ## Standard Loading Paths
@@ -44,6 +44,7 @@
 - `patterns/` - reusable patterns (setup.md example provided)
 - `tools/` - tool-specific contexts
   - `git.md` - Git conventions, PR methodology, and milestone workflow
+  - `github-actions.md` - CI/CD workflows, dependency audit, and version bump automation
 
 *Additional operational commands available in commands/ directory*
 

--- a/.ai-toolbox/tools/README.md
+++ b/.ai-toolbox/tools/README.md
@@ -5,6 +5,7 @@ Tool contexts tell AI agents how your team uses specific development tools — t
 ## Available Tools
 
 - [**git.md**](git.md) — Version control context and conventions
+- [**github-actions.md**](github-actions.md) — CI/CD workflows, dependency audit, and version bump automation
 
 *Add new tool contexts as your project needs them. See [docs/Tools.md](../docs/Tools.md) for how to add a tool context.*
 

--- a/.ai-toolbox/tools/git.md
+++ b/.ai-toolbox/tools/git.md
@@ -22,6 +22,7 @@ This project's Git conventions. AI agents apply these when generating commit mes
 
 ## PR Pattern
 - PR template: `.github/pull_request_template.md`
+- **Version bump labels**: apply one label per PR to trigger an automatic version bump on merge — `version:patch`, `version:minor`, or `version:major`. No label = no bump (correct for Dependabot, audit-fix, and infrastructure PRs). The bump runs after merge via `version-bump.yml` using `GITHUB_TOKEN`; the bump commit carries `[skip ci]` and does not trigger CI.
 
 ## Configuration
 - Key `.gitignore` patterns: `node_modules/`, `dist/`, `*-ext/`, `.sandbox/`, `*.local.*`, `.env`, `test/artifacts/`, `test/report/`

--- a/.ai-toolbox/tools/github-actions.md
+++ b/.ai-toolbox/tools/github-actions.md
@@ -1,0 +1,44 @@
+# GitHub Actions Context
+
+CI/CD workflows included in `.github/workflows/`. Load when working on automation, version management, or dependency security.
+
+## Workflows
+
+- **`build.yml`** — runs `npm run build` on every push and PR; confirms the extension compiles cleanly
+- **`lint.yml`** — runs `npm run lint` on every push and PR; confirms ESLint passes
+- **`audit.yml`** — dependency security gate; runs on every push and PR
+- **`audit-fix.yml`** — scheduled dependency fix; runs every Monday at 06:00 UTC
+- **`version-bump.yml`** — automatic version management; runs on every push to `main`
+
+## Dependency Audit (`audit.yml`)
+
+Parses `npm audit --json` and fails only if fixable vulnerabilities at `moderate` level or above are present. Unfixable vulnerabilities (`fixAvailable === false` — no third-party fix available) are logged as warnings but do not fail the gate.
+
+**When a Dependabot PR fails the audit gate:**
+1. Trigger **Audit Fix** manually from the Actions UI
+2. Set `base-branch` to the Dependabot branch name
+3. A `chore/audit-fix` PR opens targeting that branch — merge it
+4. The audit gate on the Dependabot PR passes — merge as normal
+
+**When the audit gate passes but warns about unfixable vulnerabilities:**
+No action required — the gate stays green until a third-party fix becomes available, at which point `npm audit fix` or Dependabot resolves it automatically.
+
+Dependabot (`.github/dependabot.yml`) handles direct dependency version bumps. `audit-fix.yml` handles transitive lockfile vulnerabilities. Both run weekly but serve different purposes.
+
+## Version Bump (`version-bump.yml`)
+
+Triggers on every push to `main` (after each squash merge). Reads the merged PR's labels via the GitHub API and runs `npm version patch|minor|major` accordingly. Pushes a `chore: bump version to X.Y.Z [skip ci]` commit back to `main`.
+
+- Uses `GITHUB_TOKEN` — no PAT required
+- `[skip ci]` prevents CI from re-running on the bump commit
+- No matching label = no bump; safe default for infrastructure PRs (Dependabot, audit-fix)
+
+**Version bump labels** (apply one per PR, or none to skip):
+- `version:patch` — bug fixes, dependency updates, minor corrections
+- `version:minor` — new features, backwards-compatible additions
+- `version:major` — breaking changes
+
+Labels must be created in the GitHub repo's Labels settings before the workflow can read them.
+
+---
+*Load when working on CI workflows, version management, or dependency security.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,8 +3,16 @@
 - What changed and why?
 - Link to issue(s) if any
 
+## Version bump
+
+Apply one label to trigger an automatic version bump on merge — or none to skip:
+- `version:patch` — bug fixes, dependency updates, minor corrections
+- `version:minor` — new features, backwards-compatible additions
+- `version:major` — breaking changes
+
 ## Checklist
 
+- [ ] Version bump label applied (or intentionally omitted)
 - [ ] Lint passes locally (npm run -s lint)
 - [ ] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
 - [ ] If package.json changed, I ran `npm install` and committed package-lock.json

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,4 +17,33 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm audit --audit-level=moderate
+      - name: Check for fixable vulnerabilities
+        run: |
+          npm audit --json --audit-level=moderate 2>/dev/null | node -e "
+            const chunks = [];
+            process.stdin.on('data', d => chunks.push(d));
+            process.stdin.on('end', () => {
+              const audit = JSON.parse(chunks.join(''));
+              const vulns = Object.values(audit.vulnerabilities || {});
+
+              const fixable = vulns.filter(v => v.fixAvailable !== false);
+              const unfixable = vulns.filter(v => v.fixAvailable === false);
+
+              if (unfixable.length > 0) {
+                console.warn('WARNING: ' + unfixable.length + ' unfixable vulnerability/vulnerabilities (no fix available — awaiting third-party update):');
+                unfixable.forEach(v => console.warn('  - ' + v.name + ' (' + v.severity + ')'));
+              }
+
+              if (fixable.length > 0) {
+                console.error('FAIL: ' + fixable.length + ' fixable vulnerability/vulnerabilities at moderate level or above:');
+                fixable.forEach(v => console.error('  - ' + v.name + ' (' + v.severity + ') fixAvailable: ' + JSON.stringify(v.fixAvailable)));
+                process.exit(1);
+              }
+
+              if (unfixable.length > 0) {
+                console.log('OK: No fixable vulnerabilities. ' + unfixable.length + ' unfixable vulnerability/vulnerabilities logged above — awaiting third-party updates.');
+              } else {
+                console.log('OK: No vulnerabilities found at moderate level or above.');
+              }
+            });
+          "

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,68 @@
+name: Version Bump
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Use GITHUB_TOKEN — bump commit intentionally does not trigger CI
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Resolve version bump type from PR label
+        id: bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find the PR that was merged into this push by matching the merge commit SHA.
+          # The GitHub API search endpoint returns PRs whose merge_commit_sha matches.
+          SHA="${{ github.sha }}"
+          REPO="${{ github.repository }}"
+
+          PR_LABELS=$(gh api \
+            "repos/${REPO}/commits/${SHA}/pulls" \
+            --jq '[.[0].labels[].name] | join(",")' 2>/dev/null || echo "")
+
+          echo "PR labels: $PR_LABELS"
+
+          if echo "$PR_LABELS" | grep -q "version:major"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$PR_LABELS" | grep -q "version:minor"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          elif echo "$PR_LABELS" | grep -q "version:patch"; then
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version and push
+        if: steps.bump.outputs.type != 'none'
+        run: |
+          BUMP_TYPE="${{ steps.bump.outputs.type }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          npm version "$BUMP_TYPE" --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          npm install --package-lock-only
+
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
+          git push


### PR DESCRIPTION
## Summary

Created:
-- .github/workflows/version-bump.yml: triggers on push to main; reads merged PR labels via GitHub API; runs npm version patch/minor/major and pushes a [skip ci] bump commit using GITHUB_TOKEN; no label = no bump -- .ai-toolbox/tools/github-actions.md: documents all five CI workflows, audit gate behavior (fixable vs unfixable distinction), version bump mechanics, label names, and operational runbooks for Dependabot and unfixable vulnerability scenarios

Integrated into:
-- .ai-toolbox/context.global.md: github-actions.md added to hierarchy level 3 tools listing -- .ai-toolbox/tools/README.md: github-actions.md added to Available Tools list

Updated:
-- .github/workflows/audit.yml: replaces bare npm audit call with a node script that parses npm audit --json; fails only on fixable vulnerabilities (fixAvailable !== false); logs unfixable vulnerabilities as warnings without failing the gate -- .github/pull_request_template.md: Version bump section added with label guidance; version bump label checkbox added to checklist -- .ai-toolbox/tools/git.md: PR Pattern section updated with version bump label convention and version-bump.yml reference -- .ai-toolbox/commands/initialization.md: new Step 5 (CI Workflow Decision) asks user to keep or remove workflows on initialization; remaining steps renumbered 6-10; Step 10 validation confirms CI outcome and reminds user to create labels in GitHub -- .ai-toolbox/context.development.md: CI dependency audit section removed — content now lives in tools/github-actions.md where it survives initialization

## Checklist

- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
