### PR TITLE
Prevent npm version scripts from running during automatic version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -59,7 +59,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          npm version "$BUMP_TYPE" --no-git-tag-version
+          npm version "$BUMP_TYPE" --no-git-tag-version --ignore-scripts
           NEW_VERSION=$(node -p "require('./package.json').version")
           npm install --package-lock-only
 


### PR DESCRIPTION
## Summary

Updated:
-- .github/workflows/version-bump.yml: added --ignore-scripts flag to npm version command to skip lifecycle scripts during version bump

## Version bump

- `version:patch` — bug fixes, dependency updates, minor corrections

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
