### PR TITLE
Prevent lifecycle scripts from running during automatic version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -61,7 +61,7 @@ jobs:
 
           npm version "$BUMP_TYPE" --no-git-tag-version --ignore-scripts
           NEW_VERSION=$(node -p "require('./package.json').version")
-          npm install --package-lock-only
+          npm install --package-lock-only --ignore-scripts
 
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"


### PR DESCRIPTION
## Summary

Updated:
-- .github/workflows/version-bump.yml: added --ignore-scripts flag to npm install command to prevent lifecycle scripts during package lock update in version bump workflow

## Version bump

- `version:patch` — bug fixes, dependency updates, minor corrections

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
