### PR TITLE
Chore/improve version bump workflow

### DIFF
--- a/.ai-toolbox/tools/git.md
+++ b/.ai-toolbox/tools/git.md
@@ -22,7 +22,7 @@ This project's Git conventions. AI agents apply these when generating commit mes
 
 ## PR Pattern
 - PR template: `.github/pull_request_template.md`
-- **Version bump labels**: apply one label per PR to trigger an automatic version bump on merge — `version:patch`, `version:minor`, or `version:major`. No label = no bump (correct for Dependabot, audit-fix, and infrastructure PRs). The bump runs after merge via `version-bump.yml` using `GITHUB_TOKEN`; the bump commit carries `[skip ci]` and does not trigger CI.
+- **Version bump labels**: apply one label per PR to trigger an automatic version bump on merge — `version:patch`, `version:minor`, or `version:major`. No label = no bump (correct for Dependabot, audit-fix, and infrastructure PRs). The bump runs after merge via `version-bump.yml` using `GITHUB_TOKEN`. The workflow creates a feature branch with updated `package.json` and `package-lock.json`, creates a new PR with auto-merge enabled (squash merge), and merges once status checks pass. This respects branch protection rules that require PR-based changes.
 
 ## Configuration
 - Key `.gitignore` patterns: `node_modules/`, `dist/`, `*-ext/`, `.sandbox/`, `*.local.*`, `.env`, `test/artifacts/`, `test/report/`

--- a/.ai-toolbox/tools/github-actions.md
+++ b/.ai-toolbox/tools/github-actions.md
@@ -27,10 +27,22 @@ Dependabot (`.github/dependabot.yml`) handles direct dependency version bumps. `
 
 ## Version Bump (`version-bump.yml`)
 
-Triggers on every push to `main` (after each squash merge). Reads the merged PR's labels via the GitHub API and runs `npm version patch|minor|major` accordingly. Pushes a `chore: bump version to X.Y.Z [skip ci]` commit back to `main`.
+Triggers on every push to `main` in the origin repo only (`QlikSenseStudios/qs-ext-jump-start`). Does not run on forks to prevent version clashes.
 
+**Workflow**:
+1. Reads the merged PR's labels via the GitHub API
+2. Runs `npm version patch|minor|major --no-git-tag-version --ignore-scripts`
+3. Updates `package.json` and `package-lock.json`
+4. Creates feature branch `chore/version-bump-${NEW_VERSION}`
+5. Creates a PR with auto-merge (squash merge) enabled
+6. PR merges automatically once all required status checks pass
+
+**Why this approach**: Branch protection on `main` requires all changes through PRs and mandates status checks. Direct commits are rejected. Auto-merge ensures the bump is fast-tracked after CI validation.
+
+**Key implementation details**:
 - Uses `GITHUB_TOKEN` — no PAT required
-- `[skip ci]` prevents CI from re-running on the bump commit
+- `--ignore-scripts` prevents husky execution in CI (husky is dev-only)
+- Origin repo check: `if: github.repository == 'QlikSenseStudios/qs-ext-jump-start'`
 - No matching label = no bump; safe default for infrastructure PRs (Dependabot, audit-fix)
 
 **Version bump labels** (apply one per PR, or none to skip):

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   version-bump:
+    if: github.repository == 'QlikSenseStudios/qs-ext-jump-start'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -51,8 +52,10 @@ jobs:
             echo "type=none" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Bump version and push
+      - name: Bump version and create PR
         if: steps.bump.outputs.type != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BUMP_TYPE="${{ steps.bump.outputs.type }}"
 
@@ -63,6 +66,14 @@ jobs:
           NEW_VERSION=$(node -p "require('./package.json').version")
           npm install --package-lock-only --ignore-scripts
 
+          git checkout -b "chore/version-bump-${NEW_VERSION}"
           git add package.json package-lock.json
-          git commit -m "chore: bump version to ${NEW_VERSION} [skip ci]"
-          git push
+          git commit -m "chore: bump version to ${NEW_VERSION}"
+          git push origin "chore/version-bump-${NEW_VERSION}"
+
+          gh pr create \
+            --title "chore: bump version to ${NEW_VERSION}" \
+            --body "Automated version bump" \
+            --base main \
+            --auto-merge \
+            --merge-method squash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qs-ext-jump-start",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qs-ext-jump-start",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "SEE LICENSE IN license.txt",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "component-system",
     "ui-templates"
   ],
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "license": "SEE LICENSE IN license.txt",
   "repository": {


### PR DESCRIPTION
## Summary

Migrate version bump workflow to PR-based approach with auto-merge

Updated:
-- .github/workflows/version-bump.yml: changed from direct commit push to creating feature branch and PR with auto-merge; added origin repo check to prevent version clashes in forks; added --ignore-scripts flag to npm install
-- .ai-toolbox/tools/github-actions.md: documented new PR-based workflow with rationale (respects branch protection rules); added implementation details about origin repo check and --ignore-scripts flag
-- .ai-toolbox/tools/git.md: updated version bump labels documentation to describe PR-based approach instead of direct commit with [skip ci]

## Version bump

- `version:patch` — bug fixes, dependency updates, minor corrections

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
