### PR TITLE
Grant PR creation permission to version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   version-bump:


### PR DESCRIPTION
## Summary

Updated:
-- .github/workflows/version-bump.yml: changed pull-requests permission from read to write to enable gh pr create command in automated version bump workflow

## Version bump

- `version:patch` — bug fixes, dependency updates, minor corrections

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
