### PR TITLE
Refactor version bump workflow to use explicit PR merge command

### DIFF
--- a/.ai-toolbox/tools/git.md
+++ b/.ai-toolbox/tools/git.md
@@ -22,7 +22,7 @@ This project's Git conventions. AI agents apply these when generating commit mes
 
 ## PR Pattern
 - PR template: `.github/pull_request_template.md`
-- **Version bump labels**: apply one label per PR to trigger an automatic version bump on merge — `version:patch`, `version:minor`, or `version:major`. No label = no bump (correct for Dependabot, audit-fix, and infrastructure PRs). The bump runs after merge via `version-bump.yml` using `GITHUB_TOKEN`. The workflow creates a feature branch with updated `package.json` and `package-lock.json`, creates a new PR with auto-merge enabled (squash merge), and merges once status checks pass. This respects branch protection rules that require PR-based changes.
+- **Version bump labels**: apply one label per PR to trigger an automatic version bump on merge — `version:patch`, `version:minor`, or `version:major`. No label = no bump (correct for Dependabot, audit-fix, and infrastructure PRs). The bump runs after merge via `version-bump.yml` using `GITHUB_TOKEN`. The workflow creates a feature branch with updated `package.json` and `package-lock.json`, creates a new PR via `gh pr create`, then enables auto-merge via `gh pr merge --auto --squash`. The PR merges automatically once status checks pass. This respects branch protection rules that require PR-based changes.
 
 ## Configuration
 - Key `.gitignore` patterns: `node_modules/`, `dist/`, `*-ext/`, `.sandbox/`, `*.local.*`, `.env`, `test/artifacts/`, `test/report/`

--- a/.ai-toolbox/tools/github-actions.md
+++ b/.ai-toolbox/tools/github-actions.md
@@ -34,8 +34,9 @@ Triggers on every push to `main` in the origin repo only (`QlikSenseStudios/qs-e
 2. Runs `npm version patch|minor|major --no-git-tag-version --ignore-scripts`
 3. Updates `package.json` and `package-lock.json`
 4. Creates feature branch `chore/version-bump-${NEW_VERSION}`
-5. Creates a PR with auto-merge (squash merge) enabled
-6. PR merges automatically once all required status checks pass
+5. Creates a PR and captures its URL
+6. Enables auto-merge via `gh pr merge --auto --squash`
+7. PR merges automatically once all required status checks pass
 
 **Why this approach**: Branch protection on `main` requires all changes through PRs and mandates status checks. Direct commits are rejected. Auto-merge ensures the bump is fast-tracked after CI validation.
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -71,9 +71,11 @@ jobs:
           git commit -m "chore: bump version to ${NEW_VERSION}"
           git push origin "chore/version-bump-${NEW_VERSION}"
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --title "chore: bump version to ${NEW_VERSION}" \
             --body "Automated version bump" \
             --base main \
-            --auto-merge \
-            --merge-method squash
+            --json url \
+            --jq .url)
+
+          gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

Updated:
-- .github/workflows/version-bump.yml: separated PR creation from auto-merge; now captures PR URL from gh pr create and explicitly enables auto-merge via gh pr merge --auto --squash -- .ai-toolbox/tools/github-actions.md: updated workflow steps to document two-step PR creation and auto-merge approach; clarified gh pr create and gh pr merge commands -- .ai-toolbox/tools/git.md: updated version bump labels documentation to reflect explicit gh pr create and gh pr merge commands instead of single auto-merge step

## Version bump

- `version:patch` — bug fixes, dependency updates, minor corrections

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
