### PR TITLE
Refactor version bump workflow to clean up stale branches

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -66,10 +66,15 @@ jobs:
           NEW_VERSION=$(node -p "require('./package.json').version")
           npm install --package-lock-only --ignore-scripts
 
-          git checkout -b "chore/version-bump-${NEW_VERSION}"
+          BRANCH_NAME="chore/version-bump-${NEW_VERSION}"
+
+          # Delete existing branch if it exists
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+
+          git checkout -b "$BRANCH_NAME"
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${NEW_VERSION}"
-          git push origin "chore/version-bump-${NEW_VERSION}"
+          git push origin "$BRANCH_NAME"
 
           PR_URL=$(gh pr create \
             --title "chore: bump version to ${NEW_VERSION}" \


### PR DESCRIPTION
## Summary

Updated:
-- .github/workflows/version-bump.yml: added branch name variable extraction and cleanup step to delete existing branch before creating new one; prevents "branch already exists" errors on repeated version bump runs

## Version bump

- `version:patch` — bug fixes, dependency updates, minor corrections

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
