### PR TITLE
Refactor version bump workflow to extract PR number from output inste…

### DIFF
--- a/.ai-toolbox/tools/git.md
+++ b/.ai-toolbox/tools/git.md
@@ -22,7 +22,7 @@ This project's Git conventions. AI agents apply these when generating commit mes
 
 ## PR Pattern
 - PR template: `.github/pull_request_template.md`
-- **Version bump labels**: apply one label per PR to trigger an automatic version bump on merge — `version:patch`, `version:minor`, or `version:major`. No label = no bump (correct for Dependabot, audit-fix, and infrastructure PRs). The bump runs after merge via `version-bump.yml` using `GITHUB_TOKEN`. The workflow creates a feature branch with updated `package.json` and `package-lock.json`, creates a new PR via `gh pr create`, then enables auto-merge via `gh pr merge --auto --squash`. The PR merges automatically once status checks pass. This respects branch protection rules that require PR-based changes.
+- **Version bump labels**: apply one label per PR to trigger an automatic version bump on merge — `version:patch`, `version:minor`, or `version:major`. No label = no bump (correct for Dependabot, audit-fix, and infrastructure PRs). The bump runs after merge via `version-bump.yml` using `GITHUB_TOKEN`. The workflow creates a feature branch with updated `package.json` and `package-lock.json`, creates a new PR via `gh pr create`, extracts the PR number from output, then enables auto-merge via `gh pr merge <PR_NUMBER> --auto --squash`. The PR merges automatically once status checks pass. This respects branch protection rules that require PR-based changes.
 
 ## Configuration
 - Key `.gitignore` patterns: `node_modules/`, `dist/`, `*-ext/`, `.sandbox/`, `*.local.*`, `.env`, `test/artifacts/`, `test/report/`

--- a/.ai-toolbox/tools/github-actions.md
+++ b/.ai-toolbox/tools/github-actions.md
@@ -33,10 +33,11 @@ Triggers on every push to `main` in the origin repo only (`QlikSenseStudios/qs-e
 1. Reads the merged PR's labels via the GitHub API
 2. Runs `npm version patch|minor|major --no-git-tag-version --ignore-scripts`
 3. Updates `package.json` and `package-lock.json`
-4. Creates feature branch `chore/version-bump-${NEW_VERSION}`
-5. Creates a PR and captures its URL
-6. Enables auto-merge via `gh pr merge --auto --squash`
-7. PR merges automatically once all required status checks pass
+4. Deletes existing bump branch if present to prevent push conflicts
+5. Creates feature branch `chore/version-bump-${NEW_VERSION}` and pushes it
+6. Creates a PR via `gh pr create` and extracts the PR number from the output
+7. Enables auto-merge via `gh pr merge <PR_NUMBER> --auto --squash`
+8. PR merges automatically once all required status checks pass
 
 **Why this approach**: Branch protection on `main` requires all changes through PRs and mandates status checks. Direct commits are rejected. Auto-merge ensures the bump is fast-tracked after CI validation.
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -76,11 +76,18 @@ jobs:
           git commit -m "chore: bump version to ${NEW_VERSION}"
           git push origin "$BRANCH_NAME"
 
-          PR_URL=$(gh pr create \
+          # Create PR and capture PR number from output
+          PR_OUTPUT=$(gh pr create \
             --title "chore: bump version to ${NEW_VERSION}" \
             --body "Automated version bump" \
-            --base main \
-            --json url \
-            --jq .url)
+            --base main 2>&1)
 
-          gh pr merge "$PR_URL" --auto --squash
+          # Extract PR number from output (format: "https://github.com/owner/repo/pull/NUMBER")
+          PR_NUMBER=$(echo "$PR_OUTPUT" | grep -oP 'pull/\K[0-9]+' | head -1)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Failed to create PR. Output: $PR_OUTPUT"
+            exit 1
+          fi
+
+          gh pr merge "$PR_NUMBER" --auto --squash


### PR DESCRIPTION
## Summary

Refactor version bump workflow to extract PR number from output instead of using JSON query

Updated:
-- .github/workflows/version-bump.yml: changed PR creation to capture raw output and extract PR number using regex pattern instead of relying on gh --json flag; added explicit error handling if PR number extraction fails -- .ai-toolbox/tools/github-actions.md: updated workflow steps 4-8 to document branch cleanup, PR creation with number extraction, and auto-merge as distinct operations -- .ai-toolbox/tools/git.md: updated version bump labels documentation to specify PR number extraction from output before calling gh pr merge with PR number

## Version bump

- `version:patch` — bug fixes, dependency updates, minor corrections

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
