### PR TITLE
Update Node.js version requirement to 22 and clarify version bump gui…

### DIFF
--- a/.ai-toolbox/commands/development.md
+++ b/.ai-toolbox/commands/development.md
@@ -39,15 +39,17 @@ General development patterns that work across project types.
 - Auto-sync targets (root README.md, context.state.md, context.backlog.md) are consistent with current content — if out of sync, fix immediately as a dependency
 - Lint passes: run `npm run lint` and fix all errors before closing — a change set that fails the linter cannot be committed
 - Staged/unstaged cross-check: any reference in a staged file to another file (import, path, link) must resolve against staged content — an unstaged file referenced by committed code will break anyone pulling the branch
+- Synchronized file consistency: identify related files that should be updated together (e.g., version bumps in package.json should sync with workflow files; configuration changes should sync across all affected config files) — verify all related files are either all staged or all unstaged; if some are staged and others are not, report and request staging or unstaging to achieve consistency
 - Dependent context files updated: all context files (domains/, tools/, commands/, context.*.md) that reference deleted or renamed code, APIs, or file paths are updated in this change set
 - Knowledge capture: identify any framework behavior, fragile patterns, or tool internals discovered during this work — verify they are captured in the appropriate context files per the Knowledge Capture rule before closing
+- Version bump coherence: verify the change set does not mix multiple version bump types (e.g., breaking changes alongside minor features alongside patches) in a way that would be confusing or unsafe — if so, consider splitting into separate change sets or clarifying the primary impact
 
 ## Describe Change Set
 **Purpose**: Generate a descriptive summary of the current change set suitable for recording (commit message, PR description, changelog entry, etc.)
 **Precondition**: All files intended for this commit must be staged before running this command — `git diff --cached` only reflects staged content. If files are not yet staged, stop and report that staging is required; do not attempt to describe the change set from session memory.
 **Pattern**: First retrieve the complete list of version-controlled files in the current change set (exclude gitignored and intentionally untracked files). Then for each file, run `git diff --cached` against the previously committed version and describe only what the diff shows — not what editing steps were taken during the session to produce it. If the diff shows rule A replaced by rule B, describe rule B's content relative to rule A; do not describe intermediate steps like "merged two rules." Produce output covering ALL files in the change set in the exact plain text format below. No markdown, no bold, no extra formatting. Do not use conversational session terms (e.g. "Phase 3", "this session", "as discussed") — the output must be self-contained and meaningful to anyone reading git history with no knowledge of the conversation.
 **Context**: context.global.md + all version-controlled files in the current change set + their prior recorded history
-**Output format** (plain text, copy-paste ready):
+**Output format** (plain text, copy-paste ready for commit message):
 ```
 [Short one-line description]
 
@@ -63,11 +65,28 @@ Updated:
 Fixed:
 -- [filename]: [what was corrected]
 ```
+
+**After generating the output**, provide version bump recommendation to the user:
+- State which label (`version:patch | version:minor | version:major | none`) to apply
+- Explain the rationale based on what changed
+- This recommendation guides PR labeling but is not included in the commit message itself
 **Categories**:
 - **Created** — new files with no prior recorded history
 - **Integrated into** — existing files modified only to wire in new files from this change set
 - **Updated** — existing files with substantive content changes, including auto-sync target updates (README.md, context.state.md, context.backlog.md) kept current as part of the change set
 - **Fixed** — existing files where content was incorrect or broken (wrong information, bad links, rule violations) — not routine sync lag
+
+**Version bump recommendation** (apply `version:` label to PR based on recommendation):
+- **major** — breaking changes (API changes, requirement changes, behavior changes, dropped support)
+  - Example: dropping Node 16 support, changing extension API signature
+- **minor** — new features, backwards-compatible additions, new capabilities
+  - Example: new component, new utility function, new validation rule
+- **patch** — bug fixes and dependency updates that affect users or product code
+  - Example: fix in src/state/ business logic, security patch in a used dependency, fix to extension rendering
+  - NOT: CI/CD changes, context system updates, or build tooling changes (use `none` instead)
+- **none** — infrastructure only (context system, CI/CD workflows, build tooling, internal templates) with no product-level changes
+  - Example: Node version update in workflows, GitHub Actions refactor, context system enhancements, PR template updates
+  - Key distinction: changes that don't touch src/, test/, or user-facing behavior
 
 Omit any category that has no files.
 

--- a/.ai-toolbox/context.development.md
+++ b/.ai-toolbox/context.development.md
@@ -68,6 +68,7 @@ Items specific to the example implementation (`src/` — the example table visua
 - **Visual regression tests** (Medium Value): Screenshot-based regression coverage for rendered extension states. Extension renders dynamic table with 6+ error types and selection variants; useful post-refactor but requires strict CI environment consistency. High setup effort; medium ongoing cost.
 - **Keyboard shortcut for selection** (Medium Value): Add keyboard confirm/cancel shortcuts (e.g., Escape to cancel) during active selection sessions. Selection handler already has infrastructure (`exitSelectionMode()` function). Low effort (~50 lines); improves UX for keyboard-first and a11y users.
 - **i18n support** (Medium–High Value): Internationalization scaffolding for extensions targeting multi-language tenants. Found ~30+ hardcoded UI strings (errors, hints, labels). Prerequisite: determine target locales and Qlik Sense locale strategy. Medium setup; high ongoing (string extraction and translation maintenance).
+- **Commands organization** (Low Value): Refactor commands from category-based grouping (development.md, project.md, etc.) to one-command-per-file structure. Improves discoverability, version control clarity, and mental model alignment with explicit invocation pattern. Low effort; organizational improvement only.
 
 ## Template Development Loading Paths
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,10 +5,11 @@
 
 ## Version bump
 
-Apply one label to trigger an automatic version bump on merge — or none to skip:
-- `version:patch` — bug fixes, dependency updates, minor corrections
-- `version:minor` — new features, backwards-compatible additions
-- `version:major` — breaking changes
+Apply one label to trigger an automatic version bump on merge — or omit to skip:
+- `version:major` — breaking changes (API, requirements, behavior, dropped support)
+- `version:minor` — new features, backwards-compatible additions, new capabilities
+- `version:patch` — bug fixes and dependency updates affecting users or product code (src/, test/)
+- *(Omit label)* — infrastructure only (CI/CD, context system, build tooling, templates)
 
 ## Checklist
 
@@ -16,7 +17,7 @@ Apply one label to trigger an automatic version bump on merge — or none to ski
 - [ ] Lint passes locally (npm run -s lint)
 - [ ] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
 - [ ] If package.json changed, I ran `npm install` and committed package-lock.json
-- [ ] Docs updated if behavior changed (README/docs/CHANGELOG)
+- [ ] Docs updated if behavior changed (README/docs)
 
 ## Notes for reviewers
 

--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -26,7 +26,7 @@ jobs:
           ref: ${{ inputs.base-branch || 'main' }}
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm audit fix

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - name: Check for fixable vulnerabilities

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Resolve version bump type from PR label

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
       "name": "Qlik Professional Services"
     },
     {
-      "name": "Karthik Burra",
-      "email": "karthik.burra@qlik.com"
-    },
-    {
       "name": "Gabriel Wingard",
       "email": "gabriel.wingard@qlik.com"
+    },
+    {
+      "name": "Karthik Burra",
+      "email": "karthik.burra@qlik.com"
     }
   ],
   "scripts": {
@@ -46,7 +46,7 @@
     "package": "nebula sense --meta src/meta.json"
   },
   "engines": {
-    "node": ">=20.17"
+    "node": ">=22.22.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

Update Node.js version requirement to 22 and clarify version bump guidance

Updated:
-- package.json: Node.js engine requirement upgraded from >=20.17 to >=22.22.1 -- .github/workflows/audit-fix.yml: Node.js version in setup-node action updated from 20 to 22 -- .github/workflows/audit.yml: Node.js version in setup-node action updated from 20 to 22 -- .github/workflows/build.yml: Node.js version in setup-node action updated from 20 to 22 -- .github/workflows/lint.yml: Node.js version in setup-node action updated from 20 to 22 -- .github/workflows/package.yml: Node.js version in setup-node action updated from 20 to 22 -- .github/workflows/version-bump.yml: Node.js version in setup-node action updated from 20 to 22 -- .ai-toolbox/context.development.md: added fifth Optional Enhancement item (Commands organization) documenting low-value organizational refactor opportunity from category-based grouping to one-command-per-file structure -- .ai-toolbox/commands/development.md: added two validation rules to Review Change Set checklist (synchronized file consistency and version bump coherence); expanded version bump recommendation section with concrete examples for each label (major/minor/patch/none), explicit "NOT" section for patch to clarify it excludes CI/CD and infrastructure, and key distinction noting changes must not touch src/, test/, or user-facing behavior -- .github/pull_request_template.md: PR version bump section reordered by severity (major, minor, patch, none) with clarified definitions; added explicit note that omitting label applies to infrastructure only (CI/CD, context system, build tooling, templates); clarified patch applies to changes affecting users or product code (src/, test/); removed CHANGELOG reference from documentation checklist

## Version bump

none

## Checklist

- [x] Version bump label applied (or intentionally omitted)
- [x] Lint passes locally (npm run -s lint)
- [x] I ran tests locally (npm test -s -- --reporter=list) and they passed for my environment
- [x] If package.json changed, I ran `npm install` and committed package-lock.json
